### PR TITLE
Add simple README with licence and copyright info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# GeoJSON administrative boundary line dataset
+
+This repository contains the full hierarchy of local government administrative and electoral boundaries in
+Great Britain in GeoJSON format. It's used within instances of the
+[finds.org.uk database software](https://github.com/findsorguk/findsorguk) to provide data for mapping.
+
+## Provenance
+
+The data is sourced from the
+[Boundary-Line](https://www.ordnancesurvey.co.uk/business-and-government/products/boundary-line.html)
+dataset provided by the [Ordnance Survey](https://www.ordnancesurvey.co.uk/).
+
+## Re-creating
+
+The [scripts](scripts) directory contains the original scripts used to convert the data.
+
+## Copyright and Licensing
+
+The original data was released under the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+Contains Ordnance Survey data © Crown copyright and database right 2016.


### PR DESCRIPTION
As a third party whose attention just drifted towards the repo, I'd like a little README just noting what this data is, where it comes from and how it's licensed. It's fairly easy to find this out but adding a README for a future @rjw57 is a small contribution I could make. (Writing documentation is always good, yes?)

I've tried to add a small factual README which is fairy uncontroversial but obviously I didn't create this repo or generate the data so do feel very free to correct/amend/delete as appropriate.

Finally, I don't think one is _compelled_ to include a copy of the OS OpenData licence in derivative works such as this but it feels like one is being a good citizen by at least linking to it so I added that information too.
